### PR TITLE
Improve APIRoute Typing

### DIFF
--- a/packages/astro/src/@types/astro.ts
+++ b/packages/astro/src/@types/astro.ts
@@ -1408,8 +1408,8 @@ export interface EndpointOutput {
 	encoding?: BufferEncoding;
 }
 
-export type APIRoute = (
-	context: APIContext
+export type APIRoute<T extends Record<string, any> = Record<string, any>> = (
+	context: APIContext<T>
 ) => EndpointOutput | Response | Promise<EndpointOutput | Response>;
 
 export interface EndpointHandler {


### PR DESCRIPTION
## Changes

This updates the `APIRoute` type to support specific `Props`, allowing authors to type routes more succinctly.

This is only a suggested improvement for authoring convenience. Typing without this change is provided below this example for comparison.

**Example: `/src/pages/content/[slug].js.ts`**:
```ts
import type * as TS from 'astro'

export interface Props {
  title: string
  content: string
}

export function getStaticPaths() {
  return [
    {
      params: {
        slug: 'some-slug',
      },
      props: {
        title: 'Some Title',
        content: 'Some content.',
      },
    }
  ]
}
```

**With APIRoute<T>**:
```ts
export const get: APIRoute<Props> = ({ props }) => ({
  body: `export default ${JSON.stringify(props)}`,
})
```

**Without APIRoute<T>**:
```ts
export const get = ({ props }: TS.APIContext<Props>): TS.EndpointOutput => ({
  body: `export default ${JSON.stringify(props)}`,
})
```

## Testing

This change was tested by overriding the type locally.

## Docs

/cc @withastro/maintainers-docs for feedback!